### PR TITLE
Intelligent check

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,25 @@
 # go-magi
 
-Run [check-http][] concurrently and accumulate results.
+Run [check-http][] concurrently and accumulate results without false-positive.
+
+# Motivation
+
+- primary URL: The URL that we want to check
+  - Serving **our** environment such as CMS
+- secondary URL: The URL that shares HTTP serving environment such as proxy with primary URL
+  - Serving **their** environment
+
+Sometimes we may get check failure on primary URL but actually that is caused by their enironment issues, so we want to do triage such errors.
+
+# Implementations
+
+Set `*SiteCheckResult.status` to `checkers.WARNING` (or else) if only primary URL is failed.
+
+primary: `http://example.com/subdir/` | secondary:`http://example.com/` | Total status
+------------ | ------------- | -------------
+OK | OK | OK
+OK | NG | OK
+NG | OK | NG
+NG | NG | OK
 
 [check-http]: https://github.com/mackerelio/go-check-plugins/tree/master/check-http

--- a/app.go
+++ b/app.go
@@ -85,6 +85,8 @@ func (a *App) accumulateResults(results *sync.Map) *SiteCheckResult {
 		urlResults: make(map[string]*URLCheckResult),
 		statusCode: 0,
 	}
+	var primaryURLResult *URLCheckResult
+	var secondaryURLResult *URLCheckResult
 	results.Range(func(key interface{}, value interface{}) bool {
 		var (
 			url       string
@@ -101,11 +103,17 @@ func (a *App) accumulateResults(results *sync.Map) *SiteCheckResult {
 			return true
 		}
 		result.urlResults[url] = urlResult
-		if result.statusCode < int(urlResult.status) {
-			result.statusCode = int(urlResult.status)
+		switch url {
+		case a.site.PrimaryURL:
+			primaryURLResult = urlResult
+		case a.site.SecondaryURL:
+			secondaryURLResult = urlResult
 		}
 		return true
 	})
+	if (primaryURLResult.status != checkers.OK) && (secondaryURLResult.status == checkers.OK) {
+		result.statusCode = int(primaryURLResult.status)
+	}
 	return result
 }
 

--- a/app.go
+++ b/app.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"runtime"
 	"sync"
+
+	"github.com/mackerelio/checkers"
 )
 
 // App represents execution context of CLI application.
@@ -83,7 +85,7 @@ func (a *App) checkURLs() *sync.Map {
 func (a *App) accumulateResults(results *sync.Map) *SiteCheckResult {
 	result := &SiteCheckResult{
 		urlResults: make(map[string]*URLCheckResult),
-		statusCode: 0,
+		statusCode: int(checkers.OK),
 	}
 	var primaryURLResult *URLCheckResult
 	var secondaryURLResult *URLCheckResult

--- a/app_test.go
+++ b/app_test.go
@@ -44,12 +44,12 @@ func TestAccumulateResults(t *testing.T) {
 		&siteCheckResultTestCase{
 			primaryCheckStatus:   checkers.OK,
 			secondaryCheckStatus: checkers.CRITICAL,
-			expectedStatusCode:   int(checkers.CRITICAL),
+			expectedStatusCode:   int(checkers.OK),
 		},
 		&siteCheckResultTestCase{
 			primaryCheckStatus:   checkers.CRITICAL,
 			secondaryCheckStatus: checkers.CRITICAL,
-			expectedStatusCode:   int(checkers.CRITICAL),
+			expectedStatusCode:   int(checkers.OK),
 		},
 	}
 	for _, testCase := range testCases {

--- a/url.go
+++ b/url.go
@@ -14,7 +14,8 @@ func runCheckHTTP(url string, outStream, errorStream io.Writer) (checkers.Status
 	if chkr.Status == checkers.OK {
 		return chkr.Status, nil
 	}
-	return chkr.Status, fmt.Errorf(chkr.String())
+	err := fmt.Errorf("%s: %s on %s", chkr.Status.String(), chkr.String(), url)
+	return chkr.Status, err
 }
 
 // URLCheckResult represents a result of external monitoring.


### PR DESCRIPTION
# Motivation

- primary URL: The URL that we want to check
  - Serving **our** environment such as CMS
- secondary URL: The URL that shares HTTP serving environment such as proxy with primary URL
  - Serving **their** environment

Sometimes we may get check failure on primary URL but actually that is caused by their enironment issues, so we want to do triage such errors.

# Implementations

Set `*SiteCheckResult.status` to `checkers.WARNING` (or else) if only primary URL is failed.

primary: `http://example.com/subdir/` | secondary:`http://example.com/` | Total status
------------ | ------------- | ------------- 
OK | OK | OK
OK | NG | OK
NG | OK | NG
NG | NG | OK
